### PR TITLE
fix: Improve logs and remove Session unique index

### DIFF
--- a/prisma/migrations/20250731113554_remove_session_unique_index/migration.sql
+++ b/prisma/migrations/20250731113554_remove_session_unique_index/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "Sessions_userId_deviceNonce_key";

--- a/prisma/migrations/20250731115615_delete_lost_wallets/migration.sql
+++ b/prisma/migrations/20250731115615_delete_lost_wallets/migration.sql
@@ -1,0 +1,12 @@
+/*
+
+Deletes all wallets with `status = "LOST"`, as the current app doesn't allow users to have anything else other than 1 active wallet, and those cannot be
+activated anyway.
+
+All wallets with `status = "LOST"` were created when the wallet creation during recovery was introduced, but later on that functionality was refined to simply
+delete previous wallets, at least until the UI supports multiple wallets with different statuses.
+
+*/
+
+DELETE FROM public."Wallets"
+WHERE status = 'LOST';

--- a/prisma/migrations/20250731120323_enforce_one_wallet_per_user/migration.sql
+++ b/prisma/migrations/20250731120323_enforce_one_wallet_per_user/migration.sql
@@ -1,0 +1,27 @@
+/*
+
+Find users with more than 1 ACTIVE wallet and deletes all but the last one.
+
+The current app doesn't allow users to create more than one wallet. All instances of that were a consequence of the frontend creating a new wallet as part of
+the recovery flow, and then failing to update the existing wallets status. That flow now occurs atomically on the backend, instead of being (incorrectly)
+orchestrated from the frontend.
+
+*/
+
+WITH UserWalletsToDelete AS (
+  SELECT
+    w."userId",
+    w."id",
+    -- Mark all wallets except the newest one for each user as "should be deleted"
+    CASE WHEN ROW_NUMBER() OVER (PARTITION BY w."userId" ORDER BY w."createdAt" DESC) > 1
+         THEN TRUE
+         ELSE FALSE
+    END AS "shouldBeDeleted"
+  FROM public."Wallets" w
+)
+DELETE FROM public."Wallets"
+WHERE "id" IN (
+  SELECT "id"
+  FROM UserWalletsToDelete
+  WHERE "shouldBeDeleted" = TRUE
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -550,9 +550,6 @@ model Session {
   userProfile UserProfile @relation(fields: [userId], references: [supId], onDelete: Cascade)
   userId      String      @db.Uuid
 
-  /// Note how here we don't include ip and userAgent, as we only want to keep one session per user-device, so if the IP
-  /// or the userAgent change on the same device, we simply update the session info.
-  @@unique([userId, deviceNonce], name: "userSession")
   @@index([updatedAt])
   @@map("Sessions")
 }

--- a/server/routers/share-recovery/generateWalletRecoveryChallenge.ts
+++ b/server/routers/share-recovery/generateWalletRecoveryChallenge.ts
@@ -86,9 +86,12 @@ export const generateWalletRecoveryChallenge = protectedProcedure
         });
       }
 
-      throw new TRPCError({
+      throw new TRPCError(userWallet ? {
         code: "NOT_FOUND",
         message: ErrorMessages.WALLET_NOT_FOUND,
+      } : {
+        code: "FORBIDDEN",
+        message: ErrorMessages.WALLET_NOT_ENABLED,
       });
     }
 

--- a/server/routers/share-recovery/generateWalletRecoveryChallenge.ts
+++ b/server/routers/share-recovery/generateWalletRecoveryChallenge.ts
@@ -87,11 +87,11 @@ export const generateWalletRecoveryChallenge = protectedProcedure
       }
 
       throw new TRPCError(userWallet ? {
-        code: "NOT_FOUND",
-        message: ErrorMessages.WALLET_NOT_FOUND,
-      } : {
         code: "FORBIDDEN",
         message: ErrorMessages.WALLET_NOT_ENABLED,
+      } : {
+        code: "NOT_FOUND",
+        message: ErrorMessages.WALLET_NOT_FOUND,
       });
     }
 

--- a/server/routers/share-recovery/recoverWallet.ts
+++ b/server/routers/share-recovery/recoverWallet.ts
@@ -148,9 +148,12 @@ export const recoverWallet = protectedProcedure
     }
 
     if (!userWallet || userWallet.status !== WalletStatus.ENABLED) {
-      throw new TRPCError({
+      throw new TRPCError(userWallet ? {
         code: "NOT_FOUND",
         message: ErrorMessages.WALLET_NOT_FOUND,
+      } : {
+        code: "FORBIDDEN",
+        message: ErrorMessages.WALLET_NOT_ENABLED,
       });
     }
 

--- a/server/routers/share-recovery/recoverWallet.ts
+++ b/server/routers/share-recovery/recoverWallet.ts
@@ -149,11 +149,11 @@ export const recoverWallet = protectedProcedure
 
     if (!userWallet || userWallet.status !== WalletStatus.ENABLED) {
       throw new TRPCError(userWallet ? {
-        code: "NOT_FOUND",
-        message: ErrorMessages.WALLET_NOT_FOUND,
-      } : {
         code: "FORBIDDEN",
         message: ErrorMessages.WALLET_NOT_ENABLED,
+      } : {
+        code: "NOT_FOUND",
+        message: ErrorMessages.WALLET_NOT_FOUND,
       });
     }
 

--- a/server/routers/work-shares/activateWallet.ts
+++ b/server/routers/work-shares/activateWallet.ts
@@ -117,11 +117,11 @@ export const activateWallet = protectedProcedure
 
     if (!userWallet || userWallet.status !== WalletStatus.ENABLED) {
       throw new TRPCError(userWallet ? {
-        code: "NOT_FOUND",
-        message: ErrorMessages.WALLET_NOT_FOUND,
-      } : {
         code: "FORBIDDEN",
         message: ErrorMessages.WALLET_NOT_ENABLED,
+      } : {
+        code: "NOT_FOUND",
+        message: ErrorMessages.WALLET_NOT_FOUND,
       });
     }
 

--- a/server/routers/work-shares/activateWallet.ts
+++ b/server/routers/work-shares/activateWallet.ts
@@ -116,9 +116,12 @@ export const activateWallet = protectedProcedure
     const walletPublicKey = userWallet.publicKey;
 
     if (!userWallet || userWallet.status !== WalletStatus.ENABLED) {
-      throw new TRPCError({
+      throw new TRPCError(userWallet ? {
         code: "NOT_FOUND",
         message: ErrorMessages.WALLET_NOT_FOUND,
+      } : {
+        code: "FORBIDDEN",
+        message: ErrorMessages.WALLET_NOT_ENABLED,
       });
     }
 

--- a/server/routers/work-shares/generateWalletActivationChallenge.ts
+++ b/server/routers/work-shares/generateWalletActivationChallenge.ts
@@ -54,11 +54,11 @@ export const generateWalletActivationChallenge = protectedProcedure
       }
 
       throw new TRPCError(userWallet ? {
-        code: "NOT_FOUND",
-        message: ErrorMessages.WALLET_NOT_FOUND,
-      } : {
         code: "FORBIDDEN",
         message: ErrorMessages.WALLET_NOT_ENABLED,
+      } : {
+        code: "NOT_FOUND",
+        message: ErrorMessages.WALLET_NOT_FOUND,
       });
     }
 

--- a/server/routers/work-shares/generateWalletActivationChallenge.ts
+++ b/server/routers/work-shares/generateWalletActivationChallenge.ts
@@ -53,9 +53,12 @@ export const generateWalletActivationChallenge = protectedProcedure
         });
       }
 
-      throw new TRPCError({
+      throw new TRPCError(userWallet ? {
         code: "NOT_FOUND",
         message: ErrorMessages.WALLET_NOT_FOUND,
+      } : {
+        code: "FORBIDDEN",
+        message: ErrorMessages.WALLET_NOT_ENABLED,
       });
     }
 

--- a/server/utils/challenge/clients/challenge-client-v1-rsa.ts
+++ b/server/utils/challenge/clients/challenge-client-v1-rsa.ts
@@ -168,8 +168,8 @@ async function verifyChallenge({
 
 export const ChallengeClientV1: ChallengeClient<JWKInterface> = {
   version: CHALLENGE_CLIENT_VERSION,
-  ttlMs: 120000, // 120 seconds
-  ttlRotationMs: 240000, // 240 seconds - Longer because the shares need to be regenerated, which can take some time.
+  ttlMs: 150_000, // 2.5 min = 150 seconds
+  ttlRotationMs: 300_000, // 5 min = 300 seconds - Longer because the shares need to be regenerated, which can take some time.
   getChallengeRawData,
   solveChallenge,
   verifyChallenge: process.env.BUILD_TYPE === "SDK" ? undefined as any : verifyChallenge,

--- a/server/utils/error/error.constants.ts
+++ b/server/utils/error/error.constants.ts
@@ -1,6 +1,7 @@
 export const ErrorMessages = {
   // Wallets:
   WALLET_NOT_FOUND: `Wallet not found.`,
+  WALLET_NOT_ENABLED: `Wallet not enabled.`,
   WALLET_CANNOT_BE_ENABLED: `Wallet cannot be enabled.`,
   WALLET_CANNOT_BE_DISABLED: `Wallet cannot be disabled.`,
   WALLET_NO_PRIVACY_SUPPORT: "Wallet does not support the privacy setting.",


### PR DESCRIPTION
It looks like the way Supabase handles session might be causing the same user and device to get a new session and leave the old one behind, as stated here:

> Otherwise sessions are progressively deleted from the database 24 hours after they expire, which prevents you from causing a high load on your project by accident and allows you some freedom to undo changes without adversely affecting all users.
> 
> https://supabase.com/docs/guides/auth/sessions#limiting-session-lifetime-and-number-of-allowed-sessions-per-user

That was causing an issue, as when we try to update the second session with the `deviceNonce`, there will be already another row with the same `userId` and `deviceNonce`, so the update will fail.

Also, some error messages have been improved to provide some extra details.

Lastly, 2 migrations have been added:

- The first one deletes all wallets with `status = "LOST"`, as the current app doesn't allow that anyway, and all wallets marked as `LOST` are not recoverable anyway, so it doesn't make sense to keep them around until the UI supports those.

- The second one finds users with more than 1 `ACTIVE` wallets and deletes all but the last one, as again, with the current app, it's not possible to create more than one wallet. All instances of that were a consequence of the frontend creating a new wallet as part of the recovery flow, and then failing to update the existing wallets status. That flow now occurs atomically on the backend. 